### PR TITLE
Add pytest and CI workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,21 @@
+name: Run Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run pytest
+        run: pytest -q
+

--- a/README.md
+++ b/README.md
@@ -50,3 +50,14 @@ python -m http.server --directory web 8000
 ```
 
 Then open [http://localhost:8000](http://localhost:8000) in your browser.
+
+---
+
+## 🧪 Running Tests
+
+Install the dependencies and run `pytest`:
+
+```sh
+pip install -r requirements.txt
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cryptography
 base58
+pytest

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+import re
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from identity import generate_did_key
+
+
+def test_generate_did_key_format():
+    did = generate_did_key()
+    assert did.startswith("did:key:z"), "DID should start with did:key:z"
+    # Base58 characters only
+    assert re.fullmatch(r"did:key:z[1-9A-HJ-NP-Za-km-z]+", did)
+
+
+def test_generate_did_key_unique():
+    did1 = generate_did_key()
+    did2 = generate_did_key()
+    assert did1 != did2, "Each call should generate a unique DID"


### PR DESCRIPTION
## Summary
- install `pytest`
- add tests for DID key generation
- document how to run tests
- run tests in GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ec904be9483339e9fbd7e64d8e193