### PR TITLE
Pin dependencies and update CI workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cryptography
-base58
-pytest
+cryptography==45.0.4
+base58==2.1.1
+pytest==8.4.0


### PR DESCRIPTION
## Summary
- pin package versions in `requirements.txt`
- specify Python version in the CI workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecb762a30833380520a3530ab7090