### PR TITLE
Fix README clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We welcome forks, issues, and pull requests from anyone interested in improving 
 
 **Clone the repo:**
 ```sh
-git clone git@github.com:YOUR-ORG/nukie-protocol.git
+git clone git@github.com:therealcoolnerd/nukie-protocol.git
 cd nukie-protocol
 ```
 


### PR DESCRIPTION
## Summary
- update the repository clone URL in README so contributors can clone directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecb5852188333b4b6e06463ad8f1b