### PR TITLE
Make identity importable without sys.path modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ cd nukie-protocol
 
 ## Identity Module
 
-A simple DID generator is provided in `src/identity.py`. Run it to print a new `did:key` identifier:
+A simple DID generator is provided in `identity.py`. Run it to print a new `did:key` identifier:
 
 ```sh
-python src/identity.py
+python identity.py
 ```
 
 ---

--- a/identity.py
+++ b/identity.py
@@ -1,0 +1,22 @@
+"""Identity module for generating W3C DIDs using did:key."""
+
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives import serialization
+import base58
+
+MULTICODEC_ED25519_PREFIX = b"\xed\x01"
+
+
+def generate_did_key() -> str:
+    """Generate a new did:key identifier."""
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    public_key = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    multicodec = MULTICODEC_ED25519_PREFIX + public_key
+    did = "did:key:z" + base58.b58encode(multicodec).decode()
+    return did
+
+if __name__ == "__main__":
+    print(generate_did_key())

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+setup(
+    name="nukie-protocol",
+    version="0.1.0",
+    py_modules=["identity"],
+    install_requires=["cryptography", "base58"],
+)

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,8 +1,4 @@
-import sys
-from pathlib import Path
 import re
-
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from identity import generate_did_key
 


### PR DESCRIPTION
## Summary
- expose `generate_did_key` in a top-level `identity.py` module
- package project with a simple `setup.py`
- remove manual path manipulation from `tests/test_identity.py`
- update README references to the new module

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecb660644833387dcd4c30f28e010