### PR TITLE
Fix React CDN references

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Nukie Protocol Web Frontend</title>
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react@18.2.0/umd/react.production.min.js" integrity="sha384-tMH8h3BGESGckSAVGZ82T9n90ztNXxvdwvdM6UoR56cYcf+0iGXBliJ29D+wZ/x8"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js" integrity="sha384-bm7MnzvK++ykSwVJ2tynSE5TRdN+xL418osEVF2DE/L/gfWHj91J2Sphe582B1Bh"></script>
 </head>
 <body>
 <div id="root"></div>


### PR DESCRIPTION
## Summary
- reference specific React 18.2.0 files
- add integrity hashes for React CDN scripts

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecb6c79e88333af4ec4374e3040d4