### PR TITLE
Add minimal Expo project

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Placeholder App</Text>
+    </View>
+  );
+}

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "mobile",
+    "slug": "mobile",
+    "version": "1.0.0",
+    "sdkVersion": "53.0.0",
+    "platforms": ["ios", "android"],
+    "assetBundlePatterns": ["**/*"]
+  }
+}

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,3 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+registerRootComponent(App);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mobile",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~53.0.11",
+    "expo-status-bar": "~2.2.3",
+    "react": "19.0.0",
+    "react-native": "0.79.3"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
+  },
+  "private": true
+}


### PR DESCRIPTION
## Summary
- initialize a minimal Expo app in the new `mobile` folder
- use a simple placeholder component in `App.js`
- add Expo configuration via `app.json`
- provide package.json generated from `create-expo-app`

## Testing
- `npx expo start` *(fails: required packages cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_684ee3dcd6788333b6d80f5f08c15d01