### PR TITLE
Ignore React Native artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,11 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# Node and Expo
+node_modules/
+*.expo/*
+# React Native build directories
+android/**/build/
+ios/**/build/
+# Expo debug log
+expo-debug.log


### PR DESCRIPTION
## Summary
- add Node/Expo/React Native artifacts to `.gitignore`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee833626883339f12c57979302b5a