### PR TITLE
Add persistent DID generator for mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This repository uses a `pyproject.toml` configuration for packaging and
 defines the `nukie-identity` CLI script there.
 
 **Clone the repo:**
+
 ```sh
 git clone git@github.com:YOUR-ORG/nukie-protocol.git
 cd nukie-protocol
@@ -38,6 +39,7 @@ Install the project in editable mode using the configuration from
 ```sh
 pip install -e .
 ```
+
 Install Node dependencies for formatting hooks:
 
 ```sh
@@ -51,7 +53,6 @@ npx lint-staged
 ```
 
 Husky's pre-commit hook runs this automatically on commit.
-
 
 ---
 
@@ -97,6 +98,19 @@ To try it out on Android:
    npm install
    npx expo start
    ```
+
+The `mobile/identity.js` helper exposes `generateDidKey()` for generating a
+persistent `did:key` identifier. Import and call this function anywhere in your
+React Native code to obtain the DID.
+
+```js
+import generateDidKey from "./identity";
+
+async function setup() {
+  const did = await generateDidKey();
+  console.log("Your DID:", did);
+}
+```
 
 Android is the initial target platform.
 

--- a/mobile/identity.js
+++ b/mobile/identity.js
@@ -1,0 +1,52 @@
+import * as ed from "@noble/ed25519";
+import * as SecureStore from "expo-secure-store";
+
+const STORAGE_KEY = "nukie-private-key";
+const MULTICODEC_ED25519_PREFIX = new Uint8Array([0xed, 0x01]);
+const ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+function base58Encode(bytes) {
+  if (!bytes.length) return "";
+  const digits = [0];
+  for (let i = 0; i < bytes.length; ++i) {
+    let carry = bytes[i];
+    for (let j = 0; j < digits.length; ++j) {
+      const x = digits[j] * 256 + carry;
+      digits[j] = x % 58;
+      carry = (x / 58) | 0;
+    }
+    while (carry) {
+      digits.push(carry % 58);
+      carry = (carry / 58) | 0;
+    }
+  }
+  let output = "";
+  for (let k = 0; bytes[k] === 0 && k < bytes.length - 1; k++) {
+    output += ALPHABET[0];
+  }
+  for (let q = digits.length - 1; q >= 0; q--) {
+    output += ALPHABET[digits[q]];
+  }
+  return output;
+}
+
+export async function generateDidKey() {
+  let privHex = await SecureStore.getItemAsync(STORAGE_KEY);
+  let privBytes;
+  if (!privHex) {
+    privBytes = ed.utils.randomPrivateKey();
+    privHex = ed.utils.bytesToHex(privBytes);
+    await SecureStore.setItemAsync(STORAGE_KEY, privHex);
+  } else {
+    privBytes = ed.utils.hexToBytes(privHex);
+  }
+  const pubBytes = await ed.getPublicKey(privBytes);
+  const multicodec = new Uint8Array(
+    MULTICODEC_ED25519_PREFIX.length + pubBytes.length,
+  );
+  multicodec.set(MULTICODEC_ED25519_PREFIX, 0);
+  multicodec.set(pubBytes, MULTICODEC_ED25519_PREFIX.length);
+  return "did:key:z" + base58Encode(multicodec);
+}
+
+export default generateDidKey;

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -12,7 +12,9 @@
     "expo": "~53.0.11",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
-    "react-native": "0.79.3"
+    "react-native": "0.79.3",
+    "@noble/ed25519": "^2.3.0",
+    "expo-secure-store": "~14.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"


### PR DESCRIPTION
## Summary
- generate and store Ed25519 key pairs in Expo secure storage
- expose `generateDidKey()` for the mobile app
- depend on `@noble/ed25519` and `expo-secure-store`
- document mobile DID usage in the README

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684f2cdc3d808333b08baf76d96ae9b1