### PR TITLE
Expose generate_did_key from package

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ command to print a new `did:key` identifier:
 nukie-identity
 ```
 
+You can also generate a DID programmatically from the package API:
+
+```python
+from nukie_protocol import generate_did_key
+
+did = generate_did_key()
+print(did)
+```
+
 ---
 
 ## Web Frontend Skeleton

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+from .identity import generate_did_key
+
+__all__ = ["generate_did_key"]


### PR DESCRIPTION
## Summary
- export `generate_did_key` from package root
- document using `generate_did_key` in README

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3449cde48333b0d5d6ddebca3eff