### PR TITLE
Update mobile setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,10 @@ To try it out on Android:
    ```
 3. Install dependencies and start the development server for Android:
    ```sh
-   npm install
+   npm install --legacy-peer-deps
    npx expo start
    ```
+   The `--legacy-peer-deps` flag avoids peer dependency conflicts when installing packages.
 
 The `mobile/identity.js` helper exposes a new `generateDidKey()` function for
 creating a persistent `did:key` identifier. Internally it stores the Ed25519
@@ -139,6 +140,7 @@ pytest
 ```
 ```sh
 cd mobile
-npm install
+npm install --legacy-peer-deps
 npm test
 ```
+Using `--legacy-peer-deps` here prevents peer dependency conflicts during installation.


### PR DESCRIPTION
## Summary
- use `--legacy-peer-deps` in npm install commands for the mobile app
- note that the flag avoids peer dependency issues

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install --legacy-peer-deps`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f38ac625c83338df903e38ac978fc