### PR TITLE
Add combined test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,17 +130,16 @@ Android is the initial target platform.
 
 ## 🧪 Running Tests
 
-Install the dependencies and run `pytest` for the Python modules. If you have
-Node.js installed you can also execute the React Native Jest suite:
+Install the dependencies and run the full test suite using the `npm test`
+command at the repository root. This runs both the Python tests via `pytest`
+and the React Native Jest suite:
 
 ```sh
 pip install -e .
 pip install -r requirements.txt
-pytest
-```
-```sh
 cd mobile
 npm install --legacy-peer-deps
+cd ..
 npm test
 ```
 Using `--legacy-peer-deps` here prevents peer dependency conflicts during installation.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "pytest && cd mobile && npm test",
     "prepare": "husky install"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- run Python and mobile tests via a single npm script
- update testing instructions to use `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f3ae6978c8333827571bd9996875c