### PR TITLE
Add Buffer polyfill and cryptography helper

### DIFF
--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,3 +1,6 @@
-import { registerRootComponent } from 'expo';
-import App from './App';
+import { Buffer } from "buffer";
+import { registerRootComponent } from "expo";
+import App from "./App";
+
+global.Buffer = Buffer;
 registerRootComponent(App);

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@noble/ed25519": "^2.3.0",
+        "bs58": "^5.0.0",
+        "buffer": "^6.0.3",
         "expo": "~53.0.11",
         "expo-secure-store": "~14.2.3",
         "expo-status-bar": "~2.2.3",
@@ -3886,6 +3888,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4018,6 +4026,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^4.0.0"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -4028,9 +4045,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -4048,7 +4065,7 @@
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -10770,6 +10787,30 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/whatwg-url-without-unicode/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/which": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,7 +15,9 @@
     "expo-secure-store": "~14.2.3",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
-    "react-native": "0.79.3"
+    "react-native": "0.79.3",
+    "bs58": "^5.0.0",
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/utils/identity/cryptography.js
+++ b/src/utils/identity/cryptography.js
@@ -1,0 +1,22 @@
+import * as ed from "@noble/ed25519";
+import bs58 from "bs58";
+
+const MULTICODEC_ED25519_PREFIX = new Uint8Array([0xed, 0x01]);
+
+export async function generateDIDKey() {
+  const privateKey = ed.utils.randomPrivateKey();
+  const publicKey = await ed.getPublicKey(privateKey);
+  const multicodec = new Uint8Array(
+    MULTICODEC_ED25519_PREFIX.length + publicKey.length,
+  );
+  multicodec.set(MULTICODEC_ED25519_PREFIX, 0);
+  multicodec.set(publicKey, MULTICODEC_ED25519_PREFIX.length);
+  const did = "did:key:z" + bs58.encode(multicodec);
+  return {
+    did,
+    publicKey: Buffer.from(publicKey).toString("hex"),
+    privateKey: Buffer.from(privateKey).toString("hex"),
+  };
+}
+
+export default generateDIDKey;


### PR DESCRIPTION
## Summary
- add `bs58` and `buffer` packages to the mobile app
- polyfill `Buffer` in the mobile entry point
- implement `generateDIDKey` utility using `@noble/ed25519` and `bs58`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f423fa5248333a636ba78094de8fe