### PR TITLE
Add Buffer setup and crypto test

### DIFF
--- a/mobile/__tests__/cryptography.test.js
+++ b/mobile/__tests__/cryptography.test.js
@@ -1,0 +1,20 @@
+import { generateDIDKey } from '../../src/utils/identity/cryptography';
+import * as ed from '@noble/ed25519';
+
+beforeAll(() => {
+  const crypto = require('crypto');
+  ed.etc.sha512Sync = (...msgs) => {
+    const hash = crypto.createHash('sha512');
+    for (const m of msgs) hash.update(Buffer.from(m));
+    return new Uint8Array(hash.digest());
+  };
+});
+
+describe('generateDIDKey', () => {
+  test('returns valid did:key and hex keys', async () => {
+    const { did, privateKey, publicKey } = await generateDIDKey();
+    expect(did).toMatch(/^did:key:z[1-9A-HJ-NP-Za-km-z]+$/);
+    expect(privateKey).toMatch(/^[0-9a-f]{64}$/);
+    expect(publicKey).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -5,4 +5,10 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!(expo-secure-store|@noble/ed25519)/)'
   ],
+  setupFiles: ['<rootDir>/jest.setup.js'],
+  moduleDirectories: ['node_modules', '../node_modules'],
+  moduleNameMapper: {
+    '^@noble/ed25519$': '<rootDir>/node_modules/@noble/ed25519',
+    '^bs58$': '<rootDir>/node_modules/bs58',
+  },
 };

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -1,0 +1,16 @@
+const { Buffer } = require('buffer');
+global.Buffer = Buffer;
+
+const path = require('path');
+const Module = require('module');
+const extraPaths = [
+  path.resolve(__dirname, 'node_modules'),
+  path.resolve(__dirname, '../node_modules'),
+];
+process.env.NODE_PATH = extraPaths.join(path.delimiter);
+Module.Module._initPaths();
+extraPaths.forEach((p) => {
+  if (!Module.Module.globalPaths.includes(p)) {
+    Module.Module.globalPaths.push(p);
+  }
+});


### PR DESCRIPTION
## Summary
- set up global Buffer for Jest and adjust search paths
- link setup file in `mobile/jest.config.js`
- ensure `@noble/ed25519` and `bs58` resolve for tests
- add cryptography unit tests for DID generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f432a65948333ab4a0c1e4cebfe8c