### PR TITLE
Fix missing babel runtime dependency

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mobile",
       "version": "1.0.0",
       "dependencies": {
+        "@babel/runtime": "^7.20.0",
         "@noble/ed25519": "^2.3.0",
         "bs58": "^5.0.0",
         "buffer": "^6.0.3",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -17,7 +17,8 @@
     "react": "19.0.0",
     "react-native": "0.79.3",
     "bs58": "^5.0.0",
-    "buffer": "^6.0.3"
+    "buffer": "^6.0.3",
+    "@babel/runtime": "^7.20.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary
- add `@babel/runtime` to mobile dependencies
- update mobile package lock

## Testing
- `npm test` in `mobile/`

------
https://chatgpt.com/codex/tasks/task_e_684f5e0a89f08333a976dab1d51b5b50