### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/mobile"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Summary
- configure dependabot to track npm & pip dependencies

## Testing
- `pytest -q`
- `npm test` *(fails: Cannot find module '@babel/runtime/helpers/interopRequireDefault')*

------
https://chatgpt.com/codex/tasks/task_e_684f61cabe308333981a7e9deb78e544