### PR TITLE
Fix Node cryptography helper and update Jest config

### DIFF
--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -3,7 +3,8 @@ module.exports = {
     '^.+\\.jsx?$': 'babel-jest',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(expo-secure-store|@noble/ed25519)/)'
+    'node_modules/(?!(expo-secure-store|@noble/ed25519)/)',
+    '../src/utils/identity/cryptography.js'
   ],
   setupFiles: ['<rootDir>/jest.setup.js'],
   moduleDirectories: ['node_modules', '../node_modules'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "ISC",
       "devDependencies": {
         "@babel/runtime": "^7.27.6",
+        "@noble/ed25519": "^2.3.0",
+        "bs58": "^6.0.0",
         "eslint": "^9.29.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.1.2",
@@ -246,6 +248,16 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@noble/ed25519": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
+      "integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -359,6 +371,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -381,6 +400,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
       }
     },
     "node_modules/callsites": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "type": "commonjs",
   "devDependencies": {
     "@babel/runtime": "^7.27.6",
+    "@noble/ed25519": "^2.3.0",
+    "bs58": "^6.0.0",
     "eslint": "^9.29.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",

--- a/src/utils/identity/cryptography.js
+++ b/src/utils/identity/cryptography.js
@@ -1,9 +1,10 @@
-import * as ed from "@noble/ed25519";
-import bs58 from "bs58";
+const ed = require("@noble/ed25519");
+const bs58pkg = require("bs58");
+const bs58 = bs58pkg.encode ? bs58pkg : bs58pkg.default;
 
 const MULTICODEC_ED25519_PREFIX = new Uint8Array([0xed, 0x01]);
 
-export async function generateDIDKey() {
+async function generateDIDKey() {
   const privateKey = ed.utils.randomPrivateKey();
   const publicKey = await ed.getPublicKey(privateKey);
   const multicodec = new Uint8Array(
@@ -19,4 +20,6 @@ export async function generateDIDKey() {
   };
 }
 
-export default generateDIDKey;
+module.exports = {
+  generateDIDKey,
+};


### PR DESCRIPTION
## Summary
- use CommonJS exports for the `cryptography.js` helper
- handle bs58 default export when required
- ignore helper file in Jest transforms so Babel doesn't wrap it
- add Node deps for testing (`@noble/ed25519`, `bs58`)

## Testing
- `npm test`
- `cd mobile && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f71cbe1dc8333af42e412956db536