### PR TITLE
Add mobile random value polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ To try it out on Android:
 3. Install dependencies and start the development server for Android:
    ```sh
    npm install --legacy-peer-deps
-   # installs @noble/ed25519, bs58 and buffer
+   # installs @noble/ed25519, bs58, buffer and react-native-get-random-values
    npx expo start
    ```
    The `--legacy-peer-deps` flag avoids peer dependency conflicts when installing packages. Running this command in `mobile/` installs all required packages, including `@babel/runtime`.

--- a/mobile/identity.js
+++ b/mobile/identity.js
@@ -1,3 +1,4 @@
+import 'react-native-get-random-values';
 import * as ed from "@noble/ed25519";
 import * as SecureStore from "expo-secure-store";
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -18,7 +18,8 @@
     "react-native": "0.80.0",
     "bs58": "^6.0.0",
     "buffer": "^6.0.3",
-    "@babel/runtime": "^7.20.0"
+    "@babel/runtime": "^7.20.0",
+    "react-native-get-random-values": "^1.11.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary
- add `react-native-get-random-values` dependency for mobile
- import the new package in `mobile/identity.js`
- document the extra dependency in the mobile setup guide

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `npm install --legacy-peer-deps` in `mobile`
- `npm test` *(fails: Jest cannot parse react-native modules)*

------
https://chatgpt.com/codex/tasks/task_e_684f773c9e7c8333a482bf865c80958d