### PR TITLE
Add mobile cryptography helper

### DIFF
--- a/mobile/__mocks__/react-native-get-random-values.js
+++ b/mobile/__mocks__/react-native-get-random-values.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/mobile/__tests__/cryptography.test.js
+++ b/mobile/__tests__/cryptography.test.js
@@ -1,4 +1,4 @@
-import { generateDIDKey } from '../../src/utils/identity/cryptography';
+import { generateDIDKey } from '../utils/identity/cryptography';
 import * as ed from '@noble/ed25519';
 
 beforeAll(() => {

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -3,12 +3,13 @@ module.exports = {
     '^.+\\.jsx?$': 'babel-jest',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(expo-secure-store|@noble/ed25519)/)'
+    'node_modules/(?!(expo-secure-store|@noble/ed25519|react-native-get-random-values|react-native)/)'
   ],
   setupFiles: ['<rootDir>/jest.setup.js'],
   moduleDirectories: ['node_modules', '../node_modules'],
   moduleNameMapper: {
     '^@noble/ed25519$': '<rootDir>/node_modules/@noble/ed25519',
     '^bs58$': '<rootDir>/node_modules/bs58',
+    '^react-native-get-random-values$': '<rootDir>/__mocks__/react-native-get-random-values.js',
   },
 };

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -14,3 +14,5 @@ extraPaths.forEach((p) => {
     Module.Module.globalPaths.push(p);
   }
 });
+
+global.__DEV__ = true;

--- a/mobile/utils/identity/cryptography.js
+++ b/mobile/utils/identity/cryptography.js
@@ -1,0 +1,22 @@
+import * as ed from "@noble/ed25519";
+import bs58 from "bs58";
+
+const MULTICODEC_ED25519_PREFIX = new Uint8Array([0xed, 0x01]);
+
+export async function generateDIDKey() {
+  const privateKey = ed.utils.randomPrivateKey();
+  const publicKey = await ed.getPublicKey(privateKey);
+  const multicodec = new Uint8Array(
+    MULTICODEC_ED25519_PREFIX.length + publicKey.length,
+  );
+  multicodec.set(MULTICODEC_ED25519_PREFIX, 0);
+  multicodec.set(publicKey, MULTICODEC_ED25519_PREFIX.length);
+  const did = "did:key:z" + bs58.encode(multicodec);
+  return {
+    did,
+    publicKey: Buffer.from(publicKey).toString("hex"),
+    privateKey: Buffer.from(privateKey).toString("hex"),
+  };
+}
+
+export default generateDIDKey;


### PR DESCRIPTION
## Summary
- add a mobile copy of the cryptography helper
- use the new helper in tests
- ensure Jest transpiles the helper and mock `react-native-get-random-values`
- set `__DEV__` during Jest setup

## Testing
- `npm test` in `mobile/`

------
https://chatgpt.com/codex/tasks/task_e_684f791913788333b0fc28c623edb5c4