### PR TITLE
Fix README DID import statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ nukie-identity
 You can also generate a DID programmatically from the package API:
 
 ```python
-from nukie_protocol import generate_did_key
+from identity import generate_did_key
 
 did = generate_did_key()
 print(did)


### PR DESCRIPTION
## Summary
- fix README to import from `identity` module

## Testing
- `pip install -e .`
- `python - <<'EOF'
from identity import generate_did_key
print(generate_did_key())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684f7aac06d08333b667c83c36891c7a