### PR TITLE
Add tests for src cryptography helper

### DIFF
--- a/mobile/__tests__/cryptographySrc.test.js
+++ b/mobile/__tests__/cryptographySrc.test.js
@@ -1,0 +1,20 @@
+import { generateDIDKey } from '../../src/utils/identity/cryptography';
+import * as ed from '@noble/ed25519';
+
+beforeAll(() => {
+  const crypto = require('crypto');
+  ed.etc.sha512Sync = (...msgs) => {
+    const hash = crypto.createHash('sha512');
+    for (const m of msgs) hash.update(Buffer.from(m));
+    return new Uint8Array(hash.digest());
+  };
+});
+
+describe('generateDIDKey - src version', () => {
+  test('returns valid did:key and hex keys', async () => {
+    const { did, privateKey, publicKey } = await generateDIDKey();
+    expect(did).toMatch(/^did:key:z[1-9A-HJ-NP-Za-km-z]+$/);
+    expect(privateKey).toMatch(/^[0-9a-f]{64}$/);
+    expect(publicKey).toMatch(/^[0-9a-f]{64}$/);
+  });
+});


### PR DESCRIPTION
## Summary
- add new test to cover `src/utils/identity/cryptography.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f7ca2720c8333a805d133c76c450a