### PR TITLE
Centralize JS cryptography util

### DIFF
--- a/mobile/__tests__/cryptography.test.js
+++ b/mobile/__tests__/cryptography.test.js
@@ -1,4 +1,4 @@
-import { generateDIDKey } from '../utils/identity/cryptography';
+import { generateDIDKey } from '../../src/utils/identity/cryptography';
 import * as ed from '@noble/ed25519';
 
 beforeAll(() => {

--- a/mobile/utils/identity/cryptography.js
+++ b/mobile/utils/identity/cryptography.js
@@ -1,22 +1,2 @@
-import * as ed from "@noble/ed25519";
-import bs58 from "bs58";
+export * from '../../src/utils/identity/cryptography';
 
-const MULTICODEC_ED25519_PREFIX = new Uint8Array([0xed, 0x01]);
-
-export async function generateDIDKey() {
-  const privateKey = ed.utils.randomPrivateKey();
-  const publicKey = await ed.getPublicKey(privateKey);
-  const multicodec = new Uint8Array(
-    MULTICODEC_ED25519_PREFIX.length + publicKey.length,
-  );
-  multicodec.set(MULTICODEC_ED25519_PREFIX, 0);
-  multicodec.set(publicKey, MULTICODEC_ED25519_PREFIX.length);
-  const did = "did:key:z" + bs58.encode(multicodec);
-  return {
-    did,
-    publicKey: Buffer.from(publicKey).toString("hex"),
-    privateKey: Buffer.from(privateKey).toString("hex"),
-  };
-}
-
-export default generateDIDKey;


### PR DESCRIPTION
## Summary
- move mobile cryptography util to shared location
- update tests to use the shared module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f825854a48333946857458992c747