### PR TITLE
Update Jest config for cryptography ESM handling

### DIFF
--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -3,7 +3,8 @@ module.exports = {
     '^.+\\.jsx?$': 'babel-jest',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(expo-secure-store|@noble/ed25519|react-native-get-random-values|react-native)/)'
+    'node_modules/(?!(expo-secure-store|@noble/ed25519|react-native-get-random-values|react-native)/)',
+    '../src/utils/identity/cryptography.js'
   ],
   setupFiles: ['<rootDir>/jest.setup.js'],
   moduleDirectories: ['node_modules', '../node_modules'],


### PR DESCRIPTION
## Summary
- ignore the shared cryptography helper module in mobile tests

## Testing
- `npm test` *(fails: Jest SyntaxError in cryptography.js)*

------
https://chatgpt.com/codex/tasks/task_e_684f848bbfd08333bd2de370b5574f32