### PR TITLE
Update Husky install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Install Node dependencies for formatting hooks:
 npm install
 ```
 
+This will automatically configure Git hooks via Husky using the `prepare` script.
+
+If hooks are missing, run:
+
+```sh
+npm run prepare
+```
+
 To manually run Prettier and ESLint on staged files:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "pytest && cd mobile && npm test",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- switch husky install script to use the `prepare` hook
- document auto hook installation in README

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f8c5847a0833385953d2340285ef6