### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mobile-tests.yml
+++ b/.github/workflows/mobile-tests.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   mobile-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/therealcoolnerd/nukie-protocol/security/code-scanning/2](https://github.com/therealcoolnerd/nukie-protocol/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only checks out the repository and runs tests, it likely only needs `contents: read` permission. This ensures that the workflow has the least privilege necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
